### PR TITLE
Fix parser logs (Rules and procedures)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2272,14 +2272,14 @@ function buildGame(runP) {
 		gs_console('build failed');
 		return false;
 	}
-	gs_console_append('...rules built ('+SetverbsIn.length+')');
+	gs_console_append('...rules built ('+RulesIn.length+')');
 	
 	gs_console('building procedures...');
 	if(!buildProcs()) {
 		gs_console('build failed');
 		return false;
 	}
-	gs_console_append('...rules built ('+SetverbsIn.length+')');
+	gs_console_append('...procedures built ('+Object.keys(ProcsIn).length+')');
 	
 	gs_console('building variables...');
 	if(!buildVariables()) {


### PR DESCRIPTION
Log message for parsed script had few mistakes: the number of SetVerbs built was used instead of the number of rules and procedures.