### PR TITLE
Fixed typo in HTML that broke localisation of string 'List objects in scroller'

### DIFF
--- a/index.html
+++ b/index.html
@@ -5569,7 +5569,7 @@ ConversationVerbs = [
 					<div style="display: inline-block;"><input type="checkbox" id="roomdesc_never" name="roomdesc_never" /><label for="roomdesc_never"data-localisation_key="options_never">Never</label></div>
 				</p>
 				<p>
-					<spandata-localisation_key="list_objects_in_scroller">List objects in scroller</span>
+					<span data-localisation_key="list_objects_in_scroller">List objects in scroller</span>
 					<div style="display: inline-block;"><input type="checkbox" id="listobj_always" name="listobj_always" /><label for="listobj_always"data-localisation_key="options_always">Always</label></div>
 					<div style="display: inline-block;"><input type="checkbox" id="listobj_landscape" name="listobj_landscape" /><label for="listobj_landscape"data-localisation_key="options_landscape_only">Landscape&nbsp;only</label></div>
 					<div style="display: inline-block;"><input checked="checked" type="checkbox" id="listobj_never" name="listobj_never" /><label for="listobj_never"data-localisation_key="options_never">Never</label></div>


### PR DESCRIPTION
Fixed typo in HTML that broke localisation of string 'List objects in scroller'.