### PR TITLE
Animate instantly when the user prefers reduced motion

### DIFF
--- a/index.html
+++ b/index.html
@@ -2915,7 +2915,7 @@ function gs_console_append(txt) {
 		$('#gs_console').append(txt);
 
 		var scrTop = $('#gs_console').prop("scrollHeight");
-		$('#gs_console').stop().animate({scrollTop: scrTop}, 500);
+		animate($('#gs_console'), {scrollTop: scrTop}, 500);
 	}
 }
 
@@ -2939,7 +2939,7 @@ function gs_console(txt) {
 		$('#gs_console').append('<br/>' + txt);
 		
 		var scrTop = $('#gs_console').prop("scrollHeight");
-		$('#gs_console').stop().animate({scrollTop: scrTop}, 500);
+		animate($('#gs_console'), {scrollTop: scrTop}, 500);
 	}
 }
 
@@ -3089,10 +3089,10 @@ function describe_room() {
 		
 		$('#conversation').html(html);
 		if($('#conversation').css('display')=='none') {
-			$('#conversation').slideDown();
+			slideDown($('#conversation'));
 		}
 	} else if($('#conversation').css('display')=='block') {
-		$('#conversation').slideUp();
+		slideUp($('#conversation'));
 	}
 	
 	// Room Description
@@ -3555,7 +3555,7 @@ function say(txt) {
 	
 	// animated scroll to the botton
 	var scrTop = $('#scroller').prop("scrollHeight");
-	$('#scroller').stop().animate({scrollTop: scrTop}, 500);
+	animate($('#scroller'), {scrollTop: scrTop}, 500);
 }
 function say_if(cond, trueTxt, falseTxt) {
 	if(cond) {
@@ -4293,26 +4293,26 @@ function confirm_restart() {
 	if(GAME_OVER) {
 		restart_game();
 	} else {
-		$('#prompt').slideUp();
-		$('#save_prompt').slideUp();
-		$('#restart_prompt').slideDown();
+		slideUp($('#prompt'));
+		slideUp($('#save_prompt'));
+		slideDown($('#restart_prompt'));
 	}
 }
 function really_restart() {
 	restart_game();
-	$('#restart_prompt').slideUp();
-	$('#prompt').slideDown();
+	slideUp($('#restart_prompt'));
+	slideDown($('#prompt'));
 	$('#text_in').focus();
 }
 function cancel_restart() {
-	$('#restart_prompt').slideUp();
-	$('#prompt').slideDown();
+	slideUp($('#restart_prompt'));
+	slideDown($('#prompt'));
 	$('#text_in').focus();
 }
 
 function restart_game() {
-	$('#save_prompt').slideUp();
-	$('#room_description').slideDown();
+	slideUp($('#save_prompt'));
+	slideDown($('#room_description'));
 	GAME_OVER = false;
 	Game = JSONfn.parse(INITIAL_GAME);
 	document.getElementById('scroller_content').innerHTML = '';
@@ -4863,7 +4863,7 @@ function pop_undo_state()
 	return old_state;
 }
 function undo() {
-	$('#room_description').slideDown();
+	slideDown($('#room_description'));
 	
 	dim_old_messages();
 	say('');
@@ -4905,8 +4905,8 @@ function save_game(savename) {
 			Game.title.replaceAll(/[^a-zA-Z0-9\s]/g,'');
 	}
 	
-	$('#restart_prompt').slideUp();
-	$('#save_prompt').slideDown();
+	slideUp($('#restart_prompt'));
+	slideDown($('#save_prompt'));
 	$('#save_name').val(savename).focus().select();
 }
 
@@ -4917,13 +4917,13 @@ function confirm_save() {
 	} else if(game_name.toUpperCase=='AUTOSAVE') {
 		say("'AUTOSAVE' is used internally by Gruescript. Please choose something else.");
 	} else {
-		$('#save_prompt').slideUp();
+		slideUp($('#save_prompt'));
 		SAVED_GAME_NAME = game_name;
 		store_game(game_name);
 	}
 }
 function cancel_save() {
-	$('#save_prompt').slideUp();
+	slideUp($('#save_prompt'));
 }
 function store_game(game_name, suppress_message, circumvent_thingy) {
 	game_name = game_name.toUpperCase();
@@ -5408,14 +5408,14 @@ function animate_heights() {
 }
 
 function animate_inventory_height() {
-	$('#inventory_container').stop().animate({height: $('#inventory').outerHeight()}, 300);
+	animate($('#inventory_container'), {height: $('#inventory').outerHeight()}, 300);
 	set_heights();
 }
 function animate_holding_height() {
-	$('#holding_container').stop().animate({height: $('#holding').outerHeight()}, 300);
+	animate($('#holding_container'), {height: $('#holding').outerHeight()}, 300);
 }
 function animate_room_description_height() {
-	$('#room_description_container').stop().animate({height: $('#room_description').outerHeight()}, 300);
+	animate($('#room_description_container'), {height: $('#room_description').outerHeight()}, 300);
 }
 
 function set_heights() { // no animation

--- a/res/gs-utils.js
+++ b/res/gs-utils.js
@@ -111,6 +111,32 @@ function syncScroll() {
 	SYNTAX_DIV.scrollLeft = GSEDIT.scrollLeft;
 }
 
+// animation that respects reduced-motion preference
+function allowMotion() {
+	return window.matchMedia('(prefers-reduced-motion: no-preference)').matches;
+}
+
+function animate(jQueryElement, animationProperties, duration, force) {
+	var preferredDuration = force || allowMotion() ? duration : 0;
+	return jQueryElement.stop().animate(animationProperties, preferredDuration);
+}
+
+function slideDown(jQueryElement, force) {
+	if (force || allowMotion()) {
+		return jQueryElement.slideDown();
+	} else {
+		return jQueryElement.show();
+	}
+}
+
+function slideUp(jQueryElement, force) {
+	if (force || allowMotion()) {
+		return jQueryElement.slideUp();
+	} else {
+		return jQueryElement.hide();
+	}
+}
+
 SYNTAX_HIGHLIGHTING = true;
 function toggleHighlighting() {
 	if(SYNTAX_HIGHLIGHTING) {
@@ -435,11 +461,11 @@ function doOptionsMenu() {
 	}
 	if(OPTIONS_SHOWN) {
 		$('#options_label').html("Options &darr;");
-		$('#optionsMenu').slideUp();
+		slideUp($('#optionsMenu'));
 		OPTIONS_SHOWN = false;
 	} else {
 		$('#options_label').html("Options &uarr;");
-		$('#optionsMenu').slideDown();
+		slideDown($('#optionsMenu'));
 		OPTIONS_SHOWN = true;
 		// if user leaves the menu open for 10s,
 		// check the mouse isn't still over it,
@@ -450,7 +476,7 @@ function doOptionsMenu() {
 function hideOptions() {
 	// if mouse isn't currently over the menu, hide it
 	if(!$('#optionsMenu:hover').length && !$('#optionsButton:hover').length) {
-		$('#optionsMenu').slideUp();
+		slideUp($('#optionsMenu'));
 		OPTIONS_SHOWN = false;
 	} else { // otherwise check again in 2s
 		setTimeout(()=>{hideOptions();},2000);
@@ -492,11 +518,11 @@ function doExamplesMenu() {
 	}
 	if(EXAMPLES_SHOWN) {
 		$('#examples_label').html("Examples &darr;");
-		$('#examplesMenu').slideUp();
+		slideUp($('#examplesMenu'));
 		EXAMPLES_SHOWN = false;
 	} else {
 		$('#examples_label').html("Examples &uarr;");
-		$('#examplesMenu').slideDown();
+		slideDown($('#examplesMenu'));
 		EXAMPLES_SHOWN = true;
 		// if user leaves the menu open for 10s,
 		// check the mouse isn't still over it,
@@ -507,7 +533,7 @@ function doExamplesMenu() {
 function hideExamples() {
 	// if mouse isn't currently over the menu, hide it
 	if(!$('#examplesMenu:hover').length && !$('#examplesButton:hover').length) {
-		$('#examplesMenu').slideUp();
+		slideUp($('#examplesMenu'));
 		EXAMPLES_SHOWN = false;
 	} else { // otherwise check again in 2s
 		setTimeout(()=>{hideExamples();},2000);


### PR DESCRIPTION
The [`prefers-reduced-motion` media query](https://css-tricks.com/introduction-reduced-motion-media-query/) allows users to specify an accessibility setting for less animation.

This pull request wraps all animations in helper functions that animate normally if the user prefers full animation, and instantly otherwise. They also accept a flag `force` (currently unused) to force animation in all cases.