### PR TITLE
Expand give command to force hold an already carried item

### DIFF
--- a/docs/gruescript.md
+++ b/docs/gruescript.md
@@ -769,7 +769,8 @@ whether it is carried.
 <code>give <i>thing</i></code>
 : Put a thing into the player's inventory -- they will be 'holding' the
 new thing, and the thing they were previously holding (if any) will be
-returned to their main inventory.
+returned to their main inventory. If the thing was already in the player's
+inventory, it will be placed in the 'holding' slot.
 
 <code>carry <i>thing</i></code>
 : This is identical to give, except that the player will not be holding

--- a/index.html
+++ b/index.html
@@ -4365,6 +4365,9 @@ function give_hero(thing, sneak) { // if SNEAK is true, put the thing in the inv
 			hold(thing);
 		}
 	}
+	else {
+		hold(thing); // force hold something already carried
+	}
 	Game.things[thing].props.loc = 0;
 	activate_verb(thing, 'drop');
 	deactivate_verb(thing, 'take');

--- a/index.html
+++ b/index.html
@@ -4355,20 +4355,14 @@ function uncarry(thing) {
 }
 
 function give_hero(thing, sneak) { // if SNEAK is true, put the thing in the inventory, not the PC's hands (i.e. carrying not held)
-	if(!carried(thing)) {
-		if(sneak) {
-			Game.inventory.unshift(thing);
-			activate_verb(thing,'drop');
-			deactivate_verb(thing,'take');
-			set_active(thing,'wear',has_tag(thing,'wearable'));
-		} else {
-			hold(thing);
-		}
+	if(!carried(thing) && sneak) {
+		Game.inventory.unshift(thing);
+		activate_verb(thing,'drop');
+		deactivate_verb(thing,'take');
+		set_active(thing,'wear',has_tag(thing,'wearable'));
 	}
-	else {
-		if (!sneak) {
-			hold(thing); // force hold something already carried
-		}	
+	else if (!sneak) {
+		hold(thing); // force hold something already carried	
 	}
 	Game.things[thing].props.loc = 0;
 	activate_verb(thing, 'drop');

--- a/index.html
+++ b/index.html
@@ -4366,7 +4366,9 @@ function give_hero(thing, sneak) { // if SNEAK is true, put the thing in the inv
 		}
 	}
 	else {
-		hold(thing); // force hold something already carried
+		if (!sneak) {
+			hold(thing); // force hold something already carried
+		}	
 	}
 	Game.things[thing].props.loc = 0;
 	activate_verb(thing, 'drop');


### PR DESCRIPTION
I've occasionally found it useful to force an inventory item into the holding slot using JavaScript. I was surprised that the `give` command didn't do this by default, so I've added the behaviour in this PR.